### PR TITLE
:+1: add OGP image setup

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -72,7 +72,7 @@ module.exports = function Extract(moduleOptions) {
         const imgPath = join(baseDir, name)
         return await saveRemoteImage(url.href, imgPath)
           .then(() => {
-            html = html.split(url.href).join(moduleOptions.SiteBaseUrl + options.path + '/' + name)
+            html = html.split(url.href).join(options.SiteBaseUrl + options.path + '/' + name)
           })
           .catch((e) => consola.error(e))
       })


### PR DESCRIPTION
サイトベースURLを画像のURLに追加することによって、OGPで画像カードが正しく読み込まれない問題に対処します。